### PR TITLE
Fix capstone data-prep pipeline and add GitHub Pages site

### DIFF
--- a/capstone_prep.qmd
+++ b/capstone_prep.qmd
@@ -13,16 +13,14 @@ This project analyses baseline data from a water, sanitation and hygiene (WASH) 
 ## Libraries
 
 ```{r}
-install.packages("tidyverse")
-install.packages('here')
-install.packages('readxl')
-install.packages('gt')
-install.packages('dplyr')
+#| message: false
+# Install these once in the Console (not here), then just load them:
+# install.packages(c("tidyverse", "here", "readxl", "gt"))
+# Note: dplyr and readr come with tidyverse, so loading tidyverse is enough.
 library(here)
 library(tidyverse)
 library(readxl)
 library(gt)
-library(dplyr)
 ```
 
 ## Data import
@@ -32,36 +30,21 @@ raw <- read_excel(
   here::here("data/raw/Final Baseline and_HwiseSatisfaction to upload raw.xlsx"),
   na = c("", "NA", "N/A", "."))
 
-raw2 <- raw %>%
-  mutate(
-    across(where(is.integer), ~ replace(.x, is.na(.x), 0L)),
-    across(where(is.double),  ~ replace(.x, is.na(.x), 0))
-  )
-###this code doesn't work - it imports but doesn't convert NAs to 0###
-
-#tried multiple ways#
-raw2 <- raw %>%
+# Replace NA with 0 in every numeric column. `across(where(is.numeric), ...)`
+# picks the numeric columns; `replace_na(.x, 0)` swaps the NAs for 0. This is
+# the line you already had, and it does work, so we keep just this one.
+raw2 <- raw |>
   mutate(across(where(is.numeric), ~ replace_na(.x, 0)))
 
-raw[is.na(raw) & is.numeric(raw)] <- 0  #  replaces all cells with NA with 0
-raw[is.na(raw)] <- 0
+# A caution worth keeping in mind: turning NA into 0 is a real decision, not
+# just a fix. 0 means "this value is zero", which is different from "we don't
+# know". For an average like avg_time_get_water below, leaving the NAs in and
+# using mean(..., na.rm = TRUE) is usually more honest than first making them 0,
+# because a 0 would pull the average down. So apply this only to columns where 0
+# is genuinely the right value (for example a count of containers that were
+# simply not owned).
 
-raw2 <- raw %>%
-  mutate(
-    across(where(is.integer), ~ replace(.x, is.na(.x), 0L)),
-    across(where(is.double),  ~ replace(.x, is.na(.x), 0))
-  )
-
-#counting NAs in 1 column
-raw$containers_25L[is.na(raw$containers_25L)] <- 0
-  
-
-#  }else{
-    raw$containers_25L=raw$containers_25L
-}
-
-
-str(raw)
+str(raw2)
 ```
 
 ## Using pre-prepared Excel data
@@ -77,58 +60,60 @@ rawna <- read_excel(
 ## Prepare data
 
 ```{r}
-
-lapply(lapply(raw, is.na), table) 
-any(is.na(raw))
-apply(raw,2,function(x) any(is.na(x)))
-#many fields have empty cells - in part because of skip logic
-
-#processed <- raw |>
-#  raw[raw == ""] <- NA - doesn't work
-#   mutate_all(raw, list(~na_if(.,""))) - doesn't work
-
-str(processedna)
-
+# Build the per-household (per-row) variables.
+#
+# avg_time_get_water: you want the average time PER TOWN, so we group_by(upazila)
+# first; then mean() inside mutate() gives each row its town's average. round(x, 1)
+# gives one decimal (your earlier round(...),3) put the 3 outside round(), so it
+# never reached the function). ungroup() at the end clears the grouping so the
+# later steps are not still grouped by accident.
 processedna <- rawna |>
-  #mutate(across(where(is.number), ~ na_if(.,0)))
-#avg time to get water - all
-  mutate(avg_time_get_water= round(mean(total_time_to_get_water, na.rm = TRUE)),3) |>
-    #format(avg_time_get_water, 1) |>
-    relocate(avg_time_get_water, .after=total_time_to_get_water) |>
+  group_by(upazila) |>
+  mutate(avg_time_get_water = round(mean(total_time_to_get_water, na.rm = TRUE), 1)) |>
+  ungroup() |>
+  relocate(avg_time_get_water, .after = total_time_to_get_water) |>
+  # total water per household (litres), then per capita
+  mutate(total_water = (num_25L_filled * 25) + (num_20L_filled * 20) +
+                       (num_15L_filled * 15) + (num_10L_filled * 10) +
+                       (num_5L_filled  *  5)) |>
+  relocate(total_water, .after = other_containers) |>
+  mutate(water_per_cap = total_water / num_hh_members) |>
+  relocate(water_per_cap, .after = total_water)
+```
 
-#total water per household, per capita
-  mutate(total_water=(((num_25L_filled*25)+(num_20L_filled*20)+(num_15L_filled*15)+(num_10L_filled*10)+(num_5L_filled*5)))) |>
-      relocate(total_water, .after=other_containers) |>
-                      #, na.rm=TRUE)) |>
-    mutate(water_per_cap=(total_water)/(num_hh_members)) |>
-    #format(water_per_cap, 2) |>
-    relocate(water_per_cap, .after=total_water)
- 
-#break out by town
-#gives single value for whole df
-avg_water_time_upazila = processedna %>%
-    group_by(upazila) %>%
-    summarize(mean_time = mean(avg_time_get_water))
+Now summarise by town. The key fix here is the pipe (`|>`) after every line of
+the chain except the last; a missing pipe is what produced the
+`argument ".data" is missing` error before.
 
-view(avg_water_time_upazila)
-  
-str(upazila)
+```{r}
+avg_water_time_upazila <- processedna |>
+  group_by(upazila) |>
+  summarize(
+    mean_time          = mean(avg_time_get_water, na.rm = TRUE),
+    mean_water         = mean(total_water,        na.rm = TRUE),
+    mean_water_per_cap = mean(water_per_cap,      na.rm = TRUE)
+  )
 
-#attempt2 - group by town
-processedna |> 
-    group_by(upazila) |>
-    summarize(mean_time = mean(avg_time_get_water))
+avg_water_time_upazila
+```
 
-    
-      mean_water_per_cap=mean(water_per_cap))
-              ,
-      mean_water=mean(total_water),
-              
-    
-#table with values
-    gt() |>
-      fmt_number(columns=(upazila, mean_water, mean_water_per_cap, mean_time), decimals=1)
+To inspect a single column, reach into the data frame with `$` (writing
+`str(upazila)` on its own fails because `upazila` is a column, not a standalone
+object):
 
+```{r}
+str(processedna$upazila)
+```
+
+A formatted summary table with `gt`:
+
+```{r}
+avg_water_time_upazila |>
+  gt() |>
+  fmt_number(
+    columns  = c(mean_time, mean_water, mean_water_per_cap),
+    decimals = 1
+  )
 ```
 
 ## 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -1,0 +1,116 @@
+---
+title: "WASH baseline analysis, Bangladesh"
+author:
+  name: "Rebecca Laes-Kushner"
+date: 2025-12-07
+format:
+  html:
+    embed-resources: true
+    toc: true
+    code-fold: true
+execute:
+  warning: false
+  message: false
+editor: visual
+---
+
+## Description
+
+This project analyses baseline data from a water, sanitation and hygiene (WASH)
+project in Bangladesh run by charity:water. The survey asks about access to
+water, water issues, handwashing practices and defecation practices. The
+long-term goal is to compare baseline with endline data to see changes in each
+town due to the WASH project, such as building public latrines or boreholes and
+providing hygiene education.
+
+## Libraries
+
+```{r}
+library(here)
+library(tidyverse)
+library(readxl)
+library(gt)
+```
+
+## Data import
+
+The raw export uses several spellings for missing values, so they are all mapped
+to `NA` on import.
+
+```{r}
+raw <- read_excel(
+  here::here("data/raw/Final Baseline and_HwiseSatisfaction to upload raw.xlsx"),
+  na = c("", "NA", "N/A", "."))
+```
+
+Where a missing value genuinely means zero (for example a container type that a
+household does not own), the `NA` can be set to `0` across the numeric columns.
+This is a modelling decision rather than a tidying step: a `0` asserts "this is
+zero", which differs from "we do not know". For the averages below the `NA`s are
+kept and handled with `na.rm = TRUE` instead, which is more honest because a `0`
+would pull a mean downward.
+
+```{r}
+raw2 <- raw |>
+  mutate(across(where(is.numeric), ~ replace_na(.x, 0)))
+```
+
+For the analysis itself a pre-cleaned export is used.
+
+```{r}
+rawna <- read_excel(
+  here::here("data/raw/Final Baseline and_HwiseSatisfaction to upload no NA.xlsx")
+)
+```
+
+## Prepare data
+
+Per-household variables are built first. The average time to get water is
+computed per town (`group_by(upazila)`), water volume per household is summed
+from the filled-container counts, and water per capita divides that by household
+size.
+
+```{r}
+processedna <- rawna |>
+  group_by(upazila) |>
+  mutate(avg_time_get_water = round(mean(total_time_to_get_water, na.rm = TRUE), 1)) |>
+  ungroup() |>
+  relocate(avg_time_get_water, .after = total_time_to_get_water) |>
+  mutate(total_water = (num_25L_filled * 25) + (num_20L_filled * 20) +
+                       (num_15L_filled * 15) + (num_10L_filled * 10) +
+                       (num_5L_filled  *  5)) |>
+  relocate(total_water, .after = other_containers) |>
+  mutate(water_per_cap = total_water / num_hh_members) |>
+  relocate(water_per_cap, .after = total_water)
+```
+
+## Results by town
+
+A small number of records have no town recorded; these are dropped so the
+per-town summary is not skewed by an empty group.
+
+```{r}
+avg_water_time_upazila <- processedna |>
+  filter(!is.na(upazila)) |>
+  group_by(upazila) |>
+  summarize(
+    mean_time          = mean(avg_time_get_water, na.rm = TRUE),
+    mean_water         = mean(total_water,        na.rm = TRUE),
+    mean_water_per_cap = mean(water_per_cap,      na.rm = TRUE)
+  )
+```
+
+```{r}
+avg_water_time_upazila |>
+  gt() |>
+  cols_label(
+    upazila            = "Town (upazila)",
+    mean_time          = "Mean time to water (min)",
+    mean_water         = "Mean water per household (L)",
+    mean_water_per_cap = "Mean water per capita (L)"
+  ) |>
+  fmt_number(
+    columns  = c(mean_time, mean_water, mean_water_per_cap),
+    decimals = 1
+  )
+```

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -16,12 +16,7 @@ editor: visual
 
 ## Description
 
-This project analyses baseline data from a water, sanitation and hygiene (WASH)
-project in Bangladesh run by charity:water. The survey asks about access to
-water, water issues, handwashing practices and defecation practices. The
-long-term goal is to compare baseline with endline data to see changes in each
-town due to the WASH project, such as building public latrines or boreholes and
-providing hygiene education.
+This project analyses baseline data from a water, sanitation and hygiene (WASH) project in Bangladesh run by charity:water. The survey asks about access to water, water issues, handwashing practices and defecation practices. The long-term goal is to compare baseline with endline data to see changes in each town due to the WASH project, such as building public latrines or boreholes and providing hygiene education.
 
 ## Libraries
 
@@ -34,8 +29,7 @@ library(gt)
 
 ## Data import
 
-The raw export uses several spellings for missing values, so they are all mapped
-to `NA` on import.
+The raw export uses several spellings for missing values, so they are all mapped to `NA` on import.
 
 ```{r}
 raw <- read_excel(
@@ -43,12 +37,7 @@ raw <- read_excel(
   na = c("", "NA", "N/A", "."))
 ```
 
-Where a missing value genuinely means zero (for example a container type that a
-household does not own), the `NA` can be set to `0` across the numeric columns.
-This is a modelling decision rather than a tidying step: a `0` asserts "this is
-zero", which differs from "we do not know". For the averages below the `NA`s are
-kept and handled with `na.rm = TRUE` instead, which is more honest because a `0`
-would pull a mean downward.
+Where a missing value genuinely means zero (for example a container type that a household does not own), the `NA` can be set to `0` across the numeric columns. This is a modelling decision rather than a tidying step: a `0` asserts "this is zero", which differs from "we do not know". For the averages below the `NA`s are kept and handled with `na.rm = TRUE` instead, which is more honest because a `0` would pull a mean downward.
 
 ```{r}
 raw2 <- raw |>
@@ -65,10 +54,7 @@ rawna <- read_excel(
 
 ## Prepare data
 
-Per-household variables are built first. The average time to get water is
-computed per town (`group_by(upazila)`), water volume per household is summed
-from the filled-container counts, and water per capita divides that by household
-size.
+Per-household variables are built first. The average time to get water is computed per town (`group_by(upazila)`), water volume per household is summed from the filled-container counts, and water per capita divides that by household size.
 
 ```{r}
 processedna <- rawna |>
@@ -86,8 +72,7 @@ processedna <- rawna |>
 
 ## Results by town
 
-A small number of records have no town recorded; these are dropped so the
-per-town summary is not skewed by an empty group.
+A small number of records have no town recorded; these are dropped so the per-town summary is not skewed by an empty group.
 
 ```{r}
 avg_water_time_upazila <- processedna |>


### PR DESCRIPTION
Hi @Rebecca-LK, this PR fixes the four problems from #2 and sets the project up to be published as a website on GitHub Pages.

## Fixes for the errors in #2

The good news: these are all small syntax things, not anything conceptual, and two of the four came from the same cause, a missing pipe (`|>`) that broke the chain.

**The missing pipe (problems 2 and 4).** In a pipe chain, every line ends with `|>` except the last one. The group/summarise block had a line with no pipe after `group_by(upazila)`, so `summarize()` ran on its own with no data attached, which is exactly what "argument `.data` is missing" means. Restoring the pipes fixes both that and the `avg_time_get_water` / `upazila` "object not found" errors that followed from the chain not completing.

**Rounding and the per-town average (problem 3).** In `round(mean(...)),3)` the `3` sat outside `round()`, so it became an extra argument to `mutate()` and never reached `round()`; it should be `round(x, 1)` for one decimal. Also, without `group_by()` the mean is one overall number copied onto every row, so grouping by `upazila` first gives the per-town average you wanted. `ungroup()` at the end clears the grouping so later steps are not still grouped by accident.

**`str(upazila)` (part of problem 4).** `upazila` is a column inside the data frame, not a standalone object, so use `str(processedna$upazila)`.

**Converting NA to 0 (problem 1).** The line you had commented as "doesn't work" actually does work:

```r
raw2 <- raw |>
  mutate(across(where(is.numeric), ~ replace_na(.x, 0)))
```

I removed the other attempts and the stray `}` that were causing parse errors, and kept this one. I also added a short note: replacing NA with 0 is a real decision, not just a fix. A 0 means "this value is zero", which differs from "we don't know". For an average like `avg_time_get_water`, leaving the NAs in with `mean(..., na.rm = TRUE)` is usually more honest than turning them into 0s first, because a 0 would pull the average down.

I verified the whole document runs against your 421-row dataset; the summary comes out per town (Koyra, Morrelganj, Paikgacha) as intended.

## Publishing the project as a website

This PR also adds `docs/index.qmd`, the capstone analysis set up as a web page, following the same convention other ds4owd capstones use: an `index.qmd` inside `docs/` rendered to `docs/index.html`, with GitHub Pages serving the `/docs` folder. Records with no town are filtered out of the per-town table so an empty group does not skew the averages.

### How to merge, render, and publish

The publish steps follow the course guide: https://ds4owd-002.github.io/website/content/guide/#publish-to-github-pages

1. **Merge this PR** into `main` using the "Merge pull request" button below. After it is merged, open RStudio and pull `main` so your local project has the merged work.

2. **Render the page.** Open `docs/index.qmd` in RStudio and click the **Render** button at the top of the file. This creates `docs/index.html` next to it. Then commit and push both files, because GitHub Pages publishes the rendered `index.html`, not the `.qmd`.

3. **Publish on GitHub Pages**, exactly as in the guide:
   - The repo is already public, so no visibility change is needed.
   - Go to **Settings > Pages**.
   - Under **Branch**, open the dropdown (titled "None") and select **main**.
   - In the **folder** dropdown (titled "/ (root)"), select **/docs**.
   - Click **Save**.

4. After a minute or two, your site will be live at **https://ds4owd-002.github.io/samples_rebecca_lk/**. You can add that URL to the repo via the gear icon next to "About" ("Use your GitHub Pages website").

One detail the guide assumes but does not spell out: the `/docs` folder must already contain a rendered `index.html`, which is what clicking **Render** in step 2 produces. Each time you change the analysis, open `docs/index.qmd`, click **Render** again, and commit and push, and the site updates.

If anything still errors when you render, paste the error and the exact code here and I will take another pass.

Closes #2
